### PR TITLE
Update SyncDatabaseCommand.php

### DIFF
--- a/src/SyncDatabaseCommand.php
+++ b/src/SyncDatabaseCommand.php
@@ -95,7 +95,7 @@ class SyncDatabaseCommand extends Command
 
         $filename = 'toyi-sync-database-'.md5(uniqid(rand(), true)).'.sql';
         $dump_file_remote = '/tmp/' . $filename;
-        $dump_file_local = '/tmp/' . $filename;
+        $dump_file_local = '/tmp/local-' . $filename;
         $dump_file_remote_gz = $dump_file_remote . '.gz';
         $dump_file_local_gz = $dump_file_local . '.gz';
 


### PR DESCRIPTION
Avoir un nom de chemin différent entre $dump_file_remote et $dump_file_local permet d'utiliser cette commande sur le même serveur et évite de supprimer le fichier concerné avant qu'il ne soit utilisé.